### PR TITLE
Add basic rate limiting policy and API documentation

### DIFF
--- a/apigee/src/main/apigee/apiproxies/data/apiproxy/data.xml
+++ b/apigee/src/main/apigee/apiproxies/data/apiproxy/data.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<APIProxy revision="4" name="data">
+<APIProxy revision="5" name="data">
   <DisplayName/>
   <Description/>
-  <CreatedAt>1718643372036</CreatedAt>
-  <LastModifiedAt>1718643529548</LastModifiedAt>
+  <CreatedAt>1718735448477</CreatedAt>
+  <LastModifiedAt>1718735527906</LastModifiedAt>
   <BasePaths>/data</BasePaths>
   <Policies>
     <Policy>FC-CORS</Policy>
+    <Policy>SA-RateLimit</Policy>
   </Policies>
   <ProxyEndpoints>
     <ProxyEndpoint>default</ProxyEndpoint>

--- a/apigee/src/main/apigee/apiproxies/data/apiproxy/policies/SA-RateLimit.xml
+++ b/apigee/src/main/apigee/apiproxies/data/apiproxy/policies/SA-RateLimit.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<SpikeArrest continueOnError="false" enabled="true" name="SA-RateLimit">
+  <Rate>5ps</Rate>
+</SpikeArrest>

--- a/apigee/src/main/apigee/apiproxies/data/apiproxy/proxies/default.xml
+++ b/apigee/src/main/apigee/apiproxies/data/apiproxy/proxies/default.xml
@@ -5,6 +5,9 @@
       <Step>
         <Name>FC-CORS</Name>
       </Step>
+      <Step>
+        <Name>SA-RateLimit</Name>
+      </Step>
     </Request>
   </PreFlow>
   <Flows/>

--- a/apigee/src/main/apigee/apiproxies/oauth/apiproxy/oauth.xml
+++ b/apigee/src/main/apigee/apiproxies/oauth/apiproxy/oauth.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<APIProxy revision="1" name="oauth">
+<APIProxy revision="2" name="oauth">
   <DisplayName>OAuthV2</DisplayName>
   <Description>Dispenses an OAuth 2.0 token.</Description>
-  <CreatedAt>1716992960411</CreatedAt>
-  <LastModifiedAt>1716992960411</LastModifiedAt>
+  <CreatedAt>1718735816615</CreatedAt>
+  <LastModifiedAt>1718735849840</LastModifiedAt>
   <BasePaths>/oauth/token</BasePaths>
   <Policies>
     <Policy>OAuthV2-GenerateAccessToken</Policy>
@@ -12,6 +12,7 @@
     <Policy>VerifyJWT-FirebaseIDToken</Policy>
     <Policy>AM-OAuthV2GrantType</Policy>
     <Policy>JS-CalculateAccessTokenExpirationTime</Policy>
+    <Policy>SA-RateLimit</Policy>
   </Policies>
   <ProxyEndpoints>
     <ProxyEndpoint>default</ProxyEndpoint>

--- a/apigee/src/main/apigee/apiproxies/oauth/apiproxy/policies/SA-RateLimit.xml
+++ b/apigee/src/main/apigee/apiproxies/oauth/apiproxy/policies/SA-RateLimit.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<SpikeArrest continueOnError="false" enabled="true" name="SA-RateLimit">
+  <Rate>5ps</Rate>
+</SpikeArrest>

--- a/apigee/src/main/apigee/apiproxies/oauth/apiproxy/proxies/default.xml
+++ b/apigee/src/main/apigee/apiproxies/oauth/apiproxy/proxies/default.xml
@@ -6,6 +6,9 @@
         <Name>FC-CORS</Name>
       </Step>
       <Step>
+        <Name>SA-RateLimit</Name>
+      </Step>
+      <Step>
         <Name>RF-InvalidGrantType</Name>
         <Condition>request.formparam.grant_type != "urn:ietf:params:oauth:grant-type:jwt-bearer"</Condition>
       </Step>

--- a/apigee/src/main/apigee/apiproxies/user/apiproxy/policies/SA-RateLimit.xml
+++ b/apigee/src/main/apigee/apiproxies/user/apiproxy/policies/SA-RateLimit.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<SpikeArrest continueOnError="false" enabled="true" name="SA-RateLimit">
+  <Rate>5ps</Rate>
+</SpikeArrest>

--- a/apigee/src/main/apigee/apiproxies/user/apiproxy/proxies/default.xml
+++ b/apigee/src/main/apigee/apiproxies/user/apiproxy/proxies/default.xml
@@ -6,6 +6,9 @@
         <Name>FC-CORS</Name>
       </Step>
       <Step>
+        <Name>SA-RateLimit</Name>
+      </Step>
+      <Step>
         <Name>FC-Authentication</Name>
       </Step>
     </Request>

--- a/apigee/src/main/apigee/apiproxies/user/apiproxy/user.xml
+++ b/apigee/src/main/apigee/apiproxies/user/apiproxy/user.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<APIProxy revision="1" name="user">
+<APIProxy revision="2" name="user">
   <DisplayName/>
   <Description/>
-  <CreatedAt>1718649251514</CreatedAt>
-  <LastModifiedAt>1718649906760</LastModifiedAt>
+  <CreatedAt>1718735915836</CreatedAt>
+  <LastModifiedAt>1718735915836</LastModifiedAt>
   <BasePaths>/user</BasePaths>
   <Policies>
     <Policy>FC-CORS</Policy>
     <Policy>AM-UserIdHeader</Policy>
     <Policy>FC-Authentication</Policy>
+    <Policy>SA-RateLimit</Policy>
   </Policies>
   <ProxyEndpoints>
     <ProxyEndpoint>default</ProxyEndpoint>

--- a/apigee/src/main/apigee/documentation/climateiq.yaml
+++ b/apigee/src/main/apigee/documentation/climateiq.yaml
@@ -1,0 +1,77 @@
+openapi: 3.0.0
+info:
+  title: ClimateIQ Hazard Data
+  version: 1.0.0
+servers:
+  - url: https://34.49.55.140.nip.io/data/
+
+paths:
+  /hazard/point:
+    get:
+      summary: Get hazard data for a specific point (latitude/longitude).
+      parameters:
+        - name: lat
+          in: query
+          description: Latitude of the point.
+          required: true
+          schema:
+            type: number
+            format: float
+        - name: lng
+          in: query
+          description: Longitude of the point.
+          required: true
+          schema:
+            type: number
+            format: float
+      responses:
+        '200':
+          description: Successful response containing hazard data for the point.
+
+  /hazard/polygon:
+    post:
+      summary: Get hazard data for a polygon defined by an array of points.
+      requestBody:
+        description: Array of points (latitude/longitude pairs) defining the polygon.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: array
+                items:
+                  type: number
+                  format: float
+                minItems: 2
+                maxItems: 2
+      responses:
+        '200':
+          description: Successful response containing hazard data for the polygon.
+
+  /hazard/admin_boundary:
+    get:
+      summary: Get hazard data for an administrative boundary.
+      parameters:
+        - name: admin_level
+          in: query
+          description: Administrative level (e.g., country, state, county).
+          required: true
+          schema:
+            type: string
+        - name: boundary_id
+          in: query
+          description: Unique identifier for the boundary.
+          required: true
+          schema:
+            type: string
+        - name: hazard_category
+          in: query
+          description: Category of hazard data (optional).
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response containing hazard data for the boundary.
+
+  


### PR DESCRIPTION
Adding rate limiting policies to each of the API proxies. Keeping the policies separate instead of using a shared flow because I expect that each proxy will end up defining a separate rate limit. The limit is arbitrary for now, we'll need to update it once we have more data.

The API documentation is also barebones for now. Jesus will be providing more detailed documentation later on.