### PR TITLE
Update merge cloud function to be triggered on write to GCS bucket.

### DIFF
--- a/cloud_functions/climateiq_merge_scenario_predictions_cf/main.py
+++ b/cloud_functions/climateiq_merge_scenario_predictions_cf/main.py
@@ -1,10 +1,11 @@
 import collections
 import csv
+import itertools
 import re
 import os
 
-import flask
-from google.cloud import storage
+from cloudevents import http
+from google.cloud import firestore, storage
 import functions_framework
 
 
@@ -21,35 +22,88 @@ CHUNK_FILE_NAME_PATTERN = (
     r"(?P<batch_id>\w+)/(?P<prediction_type>\w+)/(?P<model_id>\w+)/"
     r"(?P<study_area_name>\w+)/(?P<scenario_id>\w+)/(?P<chunk_id>\w+)\.csv"
 )
+# ID for the Study Areas collection in Firestore.
+STUDY_AREAS_COLLECTION_ID = "study_areas"
+# ID for the Model collection in Firestore.
+MODEL_COLLECTION_ID = "Model"
+# ID for the Runs sub-collection in Firestore.
+RUNS_COLLECTION_ID = "runs"
 
 
-@functions_framework.http
-def merge_scenario_predictions(request: flask.Request) -> tuple[str, int]:
+@functions_framework.cloud_event
+def merge_scenario_predictions(cloud_event: http.CloudEvent):
     """Merges predictions for each chunk across scenarios into single files per chunk.
 
-    TODO: Trigger based on file writes instead.
+    Triggered by writes to the input bucket. If the input bucket finally contains all
+    the chunks and scenarios (which are listed in Firestore), then the merge is
+    performed.
+
+    Some errors are printed instead of raised because they are non-recoverable, like
+    missing files (raising errors will result in the cloud function retrying).
 
     Args:
-        request: A Flask request with the query parameters: batch_id,
-            prediction_type, model_id, study_area_name.
-    Returns:
-        A tuple of the HTTP response (message, status_code).
+        cloud_event: The CloudEvent representing the storage event.
     """
+    data = cloud_event.data
+    object_name = data["name"]
+    match = re.match(CHUNK_FILE_NAME_PATTERN, object_name)
+    # Ignore files that don't match the pattern.
+    if not match:
+        return
+
+    batch_id, prediction_type, model_id, study_area_name = (
+        match.group("batch_id"),
+        match.group("prediction_type"),
+        match.group("model_id"),
+        match.group("study_area_name"),
+    )
+
     try:
-        batch_id, prediction_type, model_id, study_area_name = _get_args(
-            request, ("batch_id", "prediction_type", "model_id", "study_area_name")
-        )
+        scenario_ids = _get_expected_scenario_ids(batch_id, model_id)
+        num_chunks = _get_expected_num_chunks(study_area_name)
     except ValueError as error:
-        return f"Bad request: {error}", 400
+        print(error)
+        return
 
     storage_client = storage.Client()
     input_bucket = storage_client.bucket(INPUT_BUCKET_NAME)
-    output_bucket = storage_client.bucket(OUTPUT_BUCKET_NAME)
-
     blobs = storage_client.list_blobs(
         INPUT_BUCKET_NAME, f"{batch_id}/{prediction_type}/{model_id}/{study_area_name}"
     )
-    chunk_ids, scenario_ids = _get_chunk_and_scenario_ids(blobs)
+    chunk_ids_by_scenario_id = _get_chunk_ids_to_scenario_id(blobs)
+
+    # If the files are not all available yet in the input bucket, don't do anything.
+    try:
+        files_complete = _files_complete(
+            scenario_ids, num_chunks, chunk_ids_by_scenario_id
+        )
+    except ValueError as error:
+        print(error)
+        return
+    if not files_complete:
+        print(
+            "Not all files ready for "
+            f"{batch_id}/{prediction_type}/{model_id}/{study_area_name}"
+        )
+        return
+
+    # List of all unique chunk_ids. We expect the chunk_ids to be identical across
+    # scenarios. Sort list alphabetically for testing purposes.
+    chunk_ids = sorted(
+        list(
+            set(
+                itertools.chain.from_iterable(
+                    chunk_ids for _, chunk_ids in chunk_ids_by_scenario_id.items()
+                )
+            )
+        ),
+        key=str,
+    )
+    if len(chunk_ids) != num_chunks:
+        print("Chunk IDs should be the same across all scenarios.")
+        return
+
+    output_bucket = storage_client.bucket(OUTPUT_BUCKET_NAME)
     for chunk_id in chunk_ids:
         output_file_name = (
             f"{batch_id}/{prediction_type}/{model_id}/{study_area_name}/{chunk_id}.csv"
@@ -69,7 +123,8 @@ def merge_scenario_predictions(request: flask.Request) -> tuple[str, int]:
                 try:
                     rows = _get_file_content(input_bucket, object_name)
                 except ValueError as error:
-                    return f"Not found: {error}", 404
+                    print(f"Not found: {error}")
+                    return
                 for row in rows:
                     predictions_by_h3_index[row["h3_index"]][scenario_id] = row[
                         "prediction"
@@ -77,65 +132,101 @@ def merge_scenario_predictions(request: flask.Request) -> tuple[str, int]:
             for h3_index, predictions in predictions_by_h3_index.items():
                 missing_scenario_ids = set(scenario_ids) - set(predictions.keys())
                 if missing_scenario_ids:
-                    return (
-                        (
-                            f"Not found: Missing predictions for {h3_index} for "
-                            f"{', '.join(missing_scenario_ids)}."
-                        ),
-                        404,
+                    print(
+                        f"Not found: Missing predictions for {h3_index} for "
+                        f"{', '.join(missing_scenario_ids)}."
                     )
+                    return
                 predictions["h3_index"] = h3_index
                 # Output CSV will have the headers: h3_index,scenario_0,scenario_1...
                 writer.writerow(predictions)
-    return "Success", 200
 
 
-def _get_args(
-    request: flask.Request, arg_names: collections.abc.Iterable[str]
-) -> list[str]:
-    """Gets the args from the Flask request.
-
-    Args:
-        request: The request to get query args from.
-        arg_names: An Iterable of the names of the args to get.
-    Returns:
-        A list of the arg values ordered by arg_names.
-    Raises:
-        ValueError: If the query arg is not found in the request.
-    """
-    args = []
-    for arg_name in arg_names:
-        arg_value = request.args.get(arg_name)
-        if not arg_value:
-            raise ValueError(f"Missing arg {arg_name}")
-        args.append(arg_value)
-    return args
+def _get_expected_scenario_ids(batch_id: str, model_id: str) -> list[str]:
+    """Retrieves expected list of scenario_ids from run and model metadata."""
+    db = firestore.Client()
+    run_doc = (
+        db.collection(MODEL_COLLECTION_ID)
+        .document(model_id)
+        .collection(RUNS_COLLECTION_ID)
+        .document(batch_id)
+        .get()
+    )
+    if not run_doc.exists:
+        raise ValueError(
+            f"Metadata for run {batch_id} model {model_id} does not exist "
+            "in Firestore"
+        )
+    # Sort for predictability when testing.
+    return sorted(list(run_doc.get("scenario_ids")), key=str)
 
 
-def _get_chunk_and_scenario_ids(
-    blobs: list[storage.Blob],
-) -> tuple[list[str], list[str]]:
-    """Gets the chunk_ids and scenario_ids from a list of Blobs.
+def _get_expected_num_chunks(study_area_name: str) -> int:
+    """Retrieves number of expected chunks per scenario from study_area metadata."""
+    db = firestore.Client()
+    study_area_doc = (
+        db.collection(STUDY_AREAS_COLLECTION_ID).document(study_area_name).get()
+    )
+    if not study_area_doc.exists:
+        raise ValueError(
+            f"Metadata for study_area {study_area_name} does not exist in Firestore."
+        )
+    return study_area_doc.get("chunk_x_count") * study_area_doc.get("chunk_y_count")
 
-    We assume that every chunk_id and scenario_id combination is valid.
 
-    This ignores files which don't match the spatialized output file pattern.
-
-    Args:
-        blobs: List of Blobs to look through.
-    Returns:
-        A tuple of (chunk_ids, scenario_ids).
-    """
-    chunk_ids = set()
-    scenario_ids = set()
+def _get_chunk_ids_to_scenario_id(
+    blobs: storage.Blob,
+) -> dict[str, list[str]]:
+    """Returns a dict of scenario_ids to list of corresponding chunk_ids."""
+    chunks_per_scenario = collections.defaultdict(list)
     for blob in blobs:
         match = re.match(CHUNK_FILE_NAME_PATTERN, blob.name)
         # Ignore blobs that don't match the pattern.
         if not match:
             continue
-        chunk_ids.add(match.group("chunk_id"))
-        scenario_ids.add(match.group("scenario_id"))
-    return sorted(list(chunk_ids), key=str), sorted(list(scenario_ids), key=str)
+        chunks_per_scenario[match.group("scenario_id")].append(match.group("chunk_id"))
+    return chunks_per_scenario
+
+
+def _files_complete(
+    expected_scenario_ids: collections.abc.Iterable[str],
+    expected_num_chunks: int,
+    chunk_ids_by_scenario_id: collections.abc.Mapping[str, collections.abc.Sized],
+) -> bool:
+    """Checks if all the predictions for a batch have been written to GCS.
+
+    * Scenarios completed match scenarios expected.
+    * Each scenario has the expected number of chunks.
+
+    Args:
+        expected_scenario_ids: Iterable of scenario_ids which should be available.
+        expected_num_chunks: Number of chunks per scenario.
+        chunks_by_scenario_id: A Mapping of scenario_id to Iterable of chunk_ids derived
+            from the filenames of existing files in GCS.
+    Returns:
+        True if the files are all available in GCS.
+    Raises:
+        ValueError: If there are more scenario_ids or chunk_ids than expected found in
+            the GCS blobs.
+    """
+    actual_scenario_ids = set(chunk_ids_by_scenario_id.keys())
+    expected_scenario_ids = set(expected_scenario_ids)
+    if actual_scenario_ids == expected_scenario_ids and all(
+        len(chunk_ids) == expected_num_chunks
+        for _, chunk_ids in chunk_ids_by_scenario_id.items()
+    ):
+        return True
+    elif actual_scenario_ids > expected_scenario_ids:
+        raise ValueError("There are more scenario_ids in GCS than expected.")
+    elif any(
+        len(chunk_ids) > expected_num_chunks
+        for _, chunk_ids in chunk_ids_by_scenario_id.items()
+    ):
+        raise ValueError(
+            "There are more chunks in GCS than expected for one or more scenarios."
+        )
+    else:
+        return False
 
 
 def _get_file_content(bucket: storage.Bucket, object_name: str) -> list[dict]:

--- a/cloud_functions/climateiq_merge_scenario_predictions_cf/main_test.py
+++ b/cloud_functions/climateiq_merge_scenario_predictions_cf/main_test.py
@@ -1,18 +1,54 @@
-import re
+import collections
+import contextlib
+import io
 import tempfile
-
-import flask
-from google.cloud import storage
-import pytest
+import typing
 from unittest import mock
+
+from cloudevents import http
+from google.cloud import firestore, storage
 
 import main
 
 
-# Create a fake "app" for generating test request contexts.
-@pytest.fixture(scope="module")
-def app():
-    return flask.Flask(__name__)
+def _create_pubsub_event() -> http.CloudEvent:
+    attributes = {
+        "type": "google.cloud.storage.object.v1.finalized",
+        "source": "source",
+    }
+    data = {
+        "bucket": "climateiq-predictions",
+        "name": "batch/flood/model/nyc/scenario0/chunk0.csv",
+    }
+    return http.CloudEvent(attributes, data)
+
+
+def _create_mock_doc_snap(
+    items: collections.abc.Mapping[str, typing.Any] | None = None, exists: bool = True
+):
+    return mock.MagicMock(exists=exists, get=(items or {}).get)
+
+
+def _create_firestore_entries(
+    mock_firestore_client: mock.MagicMock, scenario_ids: list[str], num_chunks: int
+):
+    (
+        mock_firestore_client()
+        .collection()
+        .document()
+        .collection()
+        .document()
+        .get.return_value
+    ) = _create_mock_doc_snap({"scenario_ids": scenario_ids})
+
+    mock_firestore_client().collection().document().get.return_value = (
+        _create_mock_doc_snap(
+            {
+                "chunk_x_count": num_chunks,
+                "chunk_y_count": 1,
+            }
+        )
+    )
 
 
 def _create_chunk_file(
@@ -27,31 +63,38 @@ def _create_chunk_file(
     return fd.name
 
 
-def _create_mock_blob(
-    name: str, tmp_file_path: str | None = None, exists: bool = True
-) -> mock.MagicMock:
+def _create_mock_blob(name: str, tmp_file_path: str | None = None) -> mock.MagicMock:
     blob = mock.create_autospec(storage.Blob, instance=True)
     blob.name = name
     if tmp_file_path:
         blob.open.side_effect = lambda mode="r+": open(tmp_file_path, mode=mode)
-    blob.exists.return_value = exists
+        blob.exists.return_value = True
+    else:
+        blob.exists.return_value = False
     return blob
 
 
-def _create_mock_bucket(tmp_files: dict[str, str]) -> mock.MagicMock:
+def _create_mock_bucket(
+    tmp_files: collections.abc.Mapping[str, str | None]
+) -> mock.MagicMock:
     blobs = {
         name: _create_mock_blob(name, tmp_file_path)
         for name, tmp_file_path in tmp_files.items()
     }
     bucket = mock.create_autospec(storage.Bucket, instance=True)
     bucket.blob.side_effect = lambda name: blobs.get(
-        name, _create_mock_blob(name, tmp_file_path=None, exists=False)
+        name, _create_mock_blob(name, tmp_file_path=None)
     )
     return bucket
 
 
 @mock.patch.object(storage, "Client", autospec=True)
-def test_merge_scenario_predictions(mock_storage_client, tmp_path, app) -> None:
+@mock.patch.object(firestore, "Client", autospec=True)
+def test_merge_scenario_predictions(
+    mock_firestore_client, mock_storage_client, tmp_path
+):
+    _create_firestore_entries(mock_firestore_client, ["scenario0", "scenario1"], 2)
+
     input_files = {
         "batch/flood/model/nyc/scenario0/chunk0.csv": _create_chunk_file(
             {"h300": 0.00, "h301": 0.01}, tmp_path
@@ -86,33 +129,27 @@ def test_merge_scenario_predictions(mock_storage_client, tmp_path, app) -> None:
         for name, tmp_file_path in input_files.items()
         if name.startswith(prefix)
     ]
-    with app.test_request_context(
-        query_string={
-            "batch_id": "batch",
-            "prediction_type": "flood",
-            "model_id": "model",
-            "study_area_name": "nyc",
-        }
-    ):
-        result = main.merge_scenario_predictions(flask.request)
-        assert result == ("Success", 200)
 
-        expected_chunk0_contents = (
-            "h3_index,scenario0,scenario1\n" "h300,0.0,1.0\n" "h301,0.01,1.01\n"
-        )
-        expected_chunk1_contents = (
-            "h3_index,scenario0,scenario1\n" "h310,0.1,1.1\n" "h311,0.11,1.11\n"
-        )
-        with open(output_files["batch/flood/model/nyc/chunk0.csv"]) as fd:
-            assert fd.read() == expected_chunk0_contents
-        with open(output_files["batch/flood/model/nyc/chunk1.csv"]) as fd:
-            assert fd.read() == expected_chunk1_contents
+    main.merge_scenario_predictions(_create_pubsub_event())
+
+    expected_chunk0_contents = (
+        "h3_index,scenario0,scenario1\n" "h300,0.0,1.0\n" "h301,0.01,1.01\n"
+    )
+    expected_chunk1_contents = (
+        "h3_index,scenario0,scenario1\n" "h310,0.1,1.1\n" "h311,0.11,1.11\n"
+    )
+    with open(output_files["batch/flood/model/nyc/chunk0.csv"]) as fd:
+        assert fd.read() == expected_chunk0_contents
+    with open(output_files["batch/flood/model/nyc/chunk1.csv"]) as fd:
+        assert fd.read() == expected_chunk1_contents
 
 
 @mock.patch.object(storage, "Client", autospec=True)
-def test_merge_scenario_predictions_missing_chunk_raises_error(
-    mock_storage_client, tmp_path, app
-) -> None:
+@mock.patch.object(firestore, "Client", autospec=True)
+def test_merge_scenario_predictions_files_incomplete_missing_scenario(
+    mock_firestore_client, mock_storage_client, tmp_path
+):
+    _create_firestore_entries(mock_firestore_client, ["scenario0", "scenario1"], 2)
     input_files = {
         "batch/flood/model/nyc/scenario0/chunk0.csv": _create_chunk_file(
             {"h300": 0.00, "h301": 0.01}, tmp_path
@@ -120,56 +157,25 @@ def test_merge_scenario_predictions_missing_chunk_raises_error(
         "batch/flood/model/nyc/scenario0/chunk1.csv": _create_chunk_file(
             {"h310": 0.10, "h311": 0.11}, tmp_path
         ),
-        # Chunk only exists in one scenario
-        "batch/flood/model/nyc/scenario0/chunk2.csv": _create_chunk_file(
-            {"h320": 0.20, "h321": 0.21}, tmp_path
-        ),
-        "batch/flood/model/nyc/scenario1/chunk0.csv": _create_chunk_file(
-            {"h300": 1.00, "h301": 1.01}, tmp_path
-        ),
-        "batch/flood/model/nyc/scenario1/chunk1.csv": _create_chunk_file(
-            {"h310": 1.10, "h311": 1.11}, tmp_path
-        ),
     }
-    input_bucket = _create_mock_bucket(input_files)
-
-    output_files = {
-        "batch/flood/model/nyc/chunk0.csv": tmp_path / "merged_chunk0.csv",
-        "batch/flood/model/nyc/chunk1.csv": tmp_path / "merged_chunk1.csv",
-        "batch/flood/model/nyc/chunk2.csv": tmp_path / "merged_chunk2.csv",
-    }
-    output_bucket = _create_mock_bucket(output_files)
-
-    mock_storage_client().bucket.side_effect = lambda bucket_name: (
-        input_bucket if bucket_name == main.INPUT_BUCKET_NAME else output_bucket
-    )
     mock_storage_client().list_blobs.side_effect = lambda _, prefix: [
         _create_mock_blob(name, tmp_file_path)
         for name, tmp_file_path in input_files.items()
         if name.startswith(prefix)
     ]
-    with app.test_request_context(
-        query_string={
-            "batch_id": "batch",
-            "prediction_type": "flood",
-            "model_id": "model",
-            "study_area_name": "nyc",
-        }
-    ):
-        result = main.merge_scenario_predictions(flask.request)
-        assert result == (
-            (
-                "Not found: Missing predictions for "
-                "batch/flood/model/nyc/scenario1/chunk2.csv"
-            ),
-            404,
-        )
+
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        main.merge_scenario_predictions(_create_pubsub_event())
+    assert "Not all files ready" in output.getvalue()
 
 
 @mock.patch.object(storage, "Client", autospec=True)
-def test_merge_scenario_predictions_missing_scenario_for_chunk_raises_error(
-    mock_storage_client, tmp_path, app
-) -> None:
+@mock.patch.object(firestore, "Client", autospec=True)
+def test_merge_scenario_predictions_files_incomplete_missing_chunk(
+    mock_firestore_client, mock_storage_client, tmp_path
+):
+    _create_firestore_entries(mock_firestore_client, ["scenario0", "scenario1"], 2)
     input_files = {
         "batch/flood/model/nyc/scenario0/chunk0.csv": _create_chunk_file(
             {"h300": 0.00, "h301": 0.01}, tmp_path
@@ -180,13 +186,179 @@ def test_merge_scenario_predictions_missing_scenario_for_chunk_raises_error(
         "batch/flood/model/nyc/scenario1/chunk0.csv": _create_chunk_file(
             {"h300": 1.00, "h301": 1.01}, tmp_path
         ),
-        "batch/flood/model/nyc/scenario1/chunk1.csv": _create_chunk_file(
+    }
+    mock_storage_client().list_blobs.side_effect = lambda _, prefix: [
+        _create_mock_blob(name, tmp_file_path)
+        for name, tmp_file_path in input_files.items()
+        if name.startswith(prefix)
+    ]
+
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        main.merge_scenario_predictions(_create_pubsub_event())
+    assert "Not all files ready" in output.getvalue()
+
+
+@mock.patch.object(firestore, "Client", autospec=True)
+def test_merge_scenario_predictions_missing_run_metadata_prints_error(
+    mock_firestore_client,
+):
+    (
+        mock_firestore_client()
+        .collection()
+        .document()
+        .collection()
+        .document()
+        .get.return_value
+    ) = _create_mock_doc_snap(exists=False)
+
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        main.merge_scenario_predictions(_create_pubsub_event())
+    assert "Metadata for run" in output.getvalue()
+
+
+@mock.patch.object(firestore, "Client", autospec=True)
+def test_merge_scenario_predictions_missing_study_area_metadata_prints_error(
+    mock_firestore_client,
+):
+    mock_firestore_client().collection().document().get.return_value = (
+        _create_mock_doc_snap(exists=False)
+    )
+
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        main.merge_scenario_predictions(_create_pubsub_event())
+    assert "Metadata for study_area" in output.getvalue()
+
+
+@mock.patch.object(storage, "Client", autospec=True)
+@mock.patch.object(firestore, "Client", autospec=True)
+def test_merge_scenario_predictions_too_many_scenarios_prints_error(
+    mock_firestore_client, mock_storage_client, tmp_path
+):
+    _create_firestore_entries(mock_firestore_client, ["scenario0", "scenario1"], 2)
+    input_files = {
+        "batch/flood/model/nyc/scenario0/chunk0.csv": _create_chunk_file(
+            {"h300": 0.00, "h301": 0.01}, tmp_path
+        ),
+        "batch/flood/model/nyc/scenario0/chunk1.csv": _create_chunk_file(
+            {"h310": 0.10, "h311": 0.11}, tmp_path
+        ),
+        "batch/flood/model/nyc/scenario1/chunk0.csv": _create_chunk_file(
+            {"h300": 1.00, "h301": 1.01}, tmp_path
+        ),
+        "batch/flood/model/nyc/scenario1/chunk2.csv": _create_chunk_file(
             {"h310": 1.10, "h311": 1.11}, tmp_path
         ),
-        # Scenario only exists for one chunk
+        # Extra scenario
         "batch/flood/model/nyc/scenario2/chunk0.csv": _create_chunk_file(
             {"h300": 2.00, "h301": 2.01}, tmp_path
         ),
+        "batch/flood/model/nyc/scenario2/chunk1.csv": _create_chunk_file(
+            {"h310": 2.10, "h311": 2.11}, tmp_path
+        ),
+    }
+    mock_storage_client().list_blobs.side_effect = lambda _, prefix: [
+        _create_mock_blob(name, tmp_file_path)
+        for name, tmp_file_path in input_files.items()
+        if name.startswith(prefix)
+    ]
+
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        main.merge_scenario_predictions(_create_pubsub_event())
+    assert "more scenario_ids" in output.getvalue()
+
+
+@mock.patch.object(storage, "Client", autospec=True)
+@mock.patch.object(firestore, "Client", autospec=True)
+def test_merge_scenario_predictions_too_many_chunks_prints_error(
+    mock_firestore_client, mock_storage_client, tmp_path
+):
+    _create_firestore_entries(mock_firestore_client, ["scenario0", "scenario1"], 2)
+    input_files = {
+        "batch/flood/model/nyc/scenario0/chunk0.csv": _create_chunk_file(
+            {"h300": 0.00, "h301": 0.01}, tmp_path
+        ),
+        "batch/flood/model/nyc/scenario0/chunk1.csv": _create_chunk_file(
+            {"h310": 0.10, "h311": 0.11}, tmp_path
+        ),
+        "batch/flood/model/nyc/scenario1/chunk0.csv": _create_chunk_file(
+            {"h300": 1.00, "h301": 1.01}, tmp_path
+        ),
+        "batch/flood/model/nyc/scenario1/chunk1.csv": _create_chunk_file(
+            {"h310": 1.10, "h311": 1.11}, tmp_path
+        ),
+        # Extra chunk
+        "batch/flood/model/nyc/scenario1/chunk2.csv": _create_chunk_file(
+            {"h310": 1.20, "h311": 1.21}, tmp_path
+        ),
+    }
+    mock_storage_client().list_blobs.side_effect = lambda _, prefix: [
+        _create_mock_blob(name, tmp_file_path)
+        for name, tmp_file_path in input_files.items()
+        if name.startswith(prefix)
+    ]
+
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        main.merge_scenario_predictions(_create_pubsub_event())
+    assert "more chunks" in output.getvalue()
+
+
+@mock.patch.object(storage, "Client", autospec=True)
+@mock.patch.object(firestore, "Client", autospec=True)
+def test_merge_scenario_predictions_inconsistent_chunk_ids_prints_error(
+    mock_firestore_client, mock_storage_client, tmp_path
+):
+    _create_firestore_entries(mock_firestore_client, ["scenario0", "scenario1"], 2)
+    input_files = {
+        "batch/flood/model/nyc/scenario0/chunk0.csv": _create_chunk_file(
+            {"h300": 0.00, "h301": 0.01}, tmp_path
+        ),
+        "batch/flood/model/nyc/scenario0/chunk1.csv": _create_chunk_file(
+            {"h310": 0.10, "h311": 0.11}, tmp_path
+        ),
+        "batch/flood/model/nyc/scenario1/chunk0.csv": _create_chunk_file(
+            {"h300": 1.00, "h301": 1.01}, tmp_path
+        ),
+        # Inconsistent chunk ID
+        "batch/flood/model/nyc/scenario1/chunk2.csv": _create_chunk_file(
+            {"h310": 1.10, "h311": 1.11}, tmp_path
+        ),
+    }
+    mock_storage_client().list_blobs.side_effect = lambda _, prefix: [
+        _create_mock_blob(name, tmp_file_path)
+        for name, tmp_file_path in input_files.items()
+        if name.startswith(prefix)
+    ]
+
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        main.merge_scenario_predictions(_create_pubsub_event())
+    assert "Chunk IDs should be the same" in output.getvalue()
+
+
+@mock.patch.object(storage, "Client", autospec=True)
+@mock.patch.object(firestore, "Client", autospec=True)
+def test_merge_scenario_predictions_missing_chunk_prints_error(
+    mock_firestore_client, mock_storage_client, tmp_path
+):
+    _create_firestore_entries(mock_firestore_client, ["scenario0", "scenario1"], 2)
+    input_files = {
+        "batch/flood/model/nyc/scenario0/chunk0.csv": _create_chunk_file(
+            {"h300": 0.00, "h301": 0.01}, tmp_path
+        ),
+        "batch/flood/model/nyc/scenario0/chunk1.csv": _create_chunk_file(
+            {"h310": 0.10, "h311": 0.11}, tmp_path
+        ),
+        "batch/flood/model/nyc/scenario1/chunk0.csv": _create_chunk_file(
+            {"h300": 1.00, "h301": 1.01}, tmp_path
+        ),
+        # Chunk is missing, but will appear in bucket listing, to simulate if a chunk
+        # gets deleted in between the _files_complete check and reading the files.
+        "batch/flood/model/nyc/scenario1/chunk1.csv": None,
     }
     input_bucket = _create_mock_bucket(input_files)
 
@@ -204,28 +376,21 @@ def test_merge_scenario_predictions_missing_scenario_for_chunk_raises_error(
         for name, tmp_file_path in input_files.items()
         if name.startswith(prefix)
     ]
-    with app.test_request_context(
-        query_string={
-            "batch_id": "batch",
-            "prediction_type": "flood",
-            "model_id": "model",
-            "study_area_name": "nyc",
-        }
-    ):
-        result = main.merge_scenario_predictions(flask.request)
-        assert result == (
-            (
-                "Not found: Missing predictions for "
-                "batch/flood/model/nyc/scenario2/chunk1.csv"
-            ),
-            404,
-        )
+    expected_error = (
+        "Not found: Missing predictions for batch/flood/model/nyc/scenario1/chunk1.csv"
+    )
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        main.merge_scenario_predictions(_create_pubsub_event())
+    assert expected_error in output.getvalue()
 
 
 @mock.patch.object(storage, "Client", autospec=True)
-def test_merge_scenario_predictions_missing_scenarios_for_h3_index_raises_error(
-    mock_storage_client, tmp_path, app
-) -> None:
+@mock.patch.object(firestore, "Client", autospec=True)
+def test_merge_scenario_predictions_missing_scenarios_for_h3_index_prints_error(
+    mock_firestore_client, mock_storage_client, tmp_path
+):
+    _create_firestore_entries(mock_firestore_client, ["scenario0", "scenario1"], 2)
     input_files = {
         "batch/flood/model/nyc/scenario0/chunk0.csv": _create_chunk_file(
             {"h300": 0.00, "h301": 0.01}, tmp_path
@@ -256,33 +421,8 @@ def test_merge_scenario_predictions_missing_scenarios_for_h3_index_raises_error(
         for name, tmp_file_path in input_files.items()
         if name.startswith(prefix)
     ]
-    with app.test_request_context(
-        query_string={
-            "batch_id": "batch",
-            "prediction_type": "flood",
-            "model_id": "model",
-            "study_area_name": "nyc",
-        }
-    ):
-        result = main.merge_scenario_predictions(flask.request)
-        assert result == (
-            ("Not found: Missing predictions for h312 for " "scenario0."),
-            404,
-        )
-
-
-@pytest.mark.parametrize(
-    "arg_name", ["batch_id", "prediction_type", "model_id", "study_area_name"]
-)
-def test_merge_scenario_predictions_missing_args(arg_name, app):
-    query_string_args = {
-        "batch_id": "batch",
-        "prediction_type": "flood",
-        "model_id": "model",
-        "study_area_name": "nyc",
-    }
-    del query_string_args[arg_name]
-    with app.test_request_context(query_string=query_string_args):
-        result_msg, result_code = main.merge_scenario_predictions(flask.request)
-        assert re.match(f"Bad request:.*{arg_name}.*", result_msg)
-        assert result_code == 400
+    expected_error = "Not found: Missing predictions for h312 for scenario0."
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        main.merge_scenario_predictions(_create_pubsub_event())
+    assert expected_error in output.getvalue()

--- a/cloud_functions/climateiq_merge_scenario_predictions_cf/requirements.txt
+++ b/cloud_functions/climateiq_merge_scenario_predictions_cf/requirements.txt
@@ -12,6 +12,7 @@ functions-framework==3.7.0
 google-api-core==2.19.0
 google-auth==2.30.0
 google-cloud-core==2.4.1
+google-cloud-firestore==2.16.0
 google-cloud-storage==2.17.0
 google-crc32c==1.5.0
 google-resumable-media==2.7.1


### PR DESCRIPTION
Update merge cloud function to be triggered on write to GCS bucket.

Every time the CF is triggered, it checks the list of files in GCS against metadata for the run in Firestore. If all the expected files have been written, then the CF proceeds to create output files merging all the predictions across scenarios by chunk_id. Else, the CF does not proceed and it's a no-op.