### PR TITLE
Change Collection Name Model -> models

### DIFF
--- a/cloud_functions/climateiq_merge_scenario_predictions_cf/main.py
+++ b/cloud_functions/climateiq_merge_scenario_predictions_cf/main.py
@@ -25,7 +25,7 @@ CHUNK_FILE_NAME_PATTERN = (
 # ID for the Study Areas collection in Firestore.
 STUDY_AREAS_COLLECTION_ID = "study_areas"
 # ID for the Model collection in Firestore.
-MODEL_COLLECTION_ID = "Model"
+MODEL_COLLECTION_ID = "models"
 # ID for the Runs sub-collection in Firestore.
 RUNS_COLLECTION_ID = "runs"
 


### PR DESCRIPTION
I copied documents from the 'Model' collection to the 'models' collection, so the code will work either way.
'models' is what we want to use going forward to match the other collection names. It's what we're currently writing to during model training.