### PR TITLE
Make trigger_export and spatialize more efficient, and change spatialize to be triggered by CF.

### DIFF
--- a/cloud_functions/climateiq_spatialize_chunk_predictions_cf/main.py
+++ b/cloud_functions/climateiq_spatialize_chunk_predictions_cf/main.py
@@ -89,6 +89,8 @@ def spatialize_chunk_predictions(request: flask.Request):
     with blob.open("w") as fd:
         h3_predictions.to_csv(fd)
 
+    return "Success!"
+
 
 # TODO: Modify this logic once CNN output schema is confirmed. Also update to
 # account for errors and special values.

--- a/cloud_functions/climateiq_spatialize_chunk_predictions_cf/main_test.py
+++ b/cloud_functions/climateiq_spatialize_chunk_predictions_cf/main_test.py
@@ -387,7 +387,7 @@ def test_spatialize_chunk_predictions_missing_expected_neighbor_chunk(
     ):
         with pytest.raises(
             ValueError,
-            match="Neighbor chunk at index (0, 1) is missing from the study area",
+            match=r"Neighbor chunk at index \(0, 1\) is missing from the study area",
         ):
             main.spatialize_chunk_predictions(flask.request)
 
@@ -445,8 +445,9 @@ def test_spatialize_chunk_predictions_invalid_neighbor_chunk(
         with pytest.raises(
             ValueError,
             match=(
-                "Neighbor chunk at index (0, 1) is missing one or more required fields:"
-                " id, row_count, col_count, x_ll_corner,y_ll_corner, x_index, y_index"
+                r"Neighbor chunk at index \(0, 1\) is missing one or more required "
+                "fields: id, row_count, col_count, x_ll_corner,y_ll_corner, x_index, "
+                "y_index"
             ),
         ):
             main.spatialize_chunk_predictions(flask.request)

--- a/cloud_functions/climateiq_spatialize_chunk_predictions_cf/main_test.py
+++ b/cloud_functions/climateiq_spatialize_chunk_predictions_cf/main_test.py
@@ -1,16 +1,20 @@
-import base64
+import json
 import tempfile
-import io
-import contextlib
-import pandas as pd
 
-from cloudevents import http
-from google.cloud import firestore_v1
-from google.cloud import storage
+import flask
+from google.cloud import firestore_v1, storage
+import pandas as pd
+import pytest
 from typing import Any, Dict, List
 from unittest import mock
 
 import main
+
+
+def _create_request_context(object_name: str) -> flask.ctx.RequestContext:
+    return flask.Flask(__name__).test_request_context(
+        data=json.dumps({"object_name": object_name}), content_type="application/json"
+    )
 
 
 def _create_tmpfile(contents: str, dir: str) -> str:
@@ -43,27 +47,16 @@ def _create_mock_bucket(tmp_files: dict[str, str]) -> mock.MagicMock:
 
 
 def test_spatialize_chunk_predictions_invalid_object_name() -> None:
-    event = http.CloudEvent(
-        {
-            "type": "google.cloud.pubsub.topic.v1.messagePublished",
-            "source": "source",
-        },
-        {
-            "message": {
-                "data": base64.b64encode(b"invalid_name"),
-            }
-        },
-    )
-
-    output = io.StringIO()
-    with contextlib.redirect_stdout(output):
-        main.spatialize_chunk_predictions(event)
-
-    assert (
-        "Invalid object name format. Expected format: '<id>/<prediction_type>/"
-        "<model_id>/<study_area_name>/<scenario_id>/<chunk_id>'"
-        "\nActual name: 'invalid_name'" in output.getvalue()
-    )
+    with _create_request_context("invalid_name"):
+        with pytest.raises(
+            ValueError,
+            match=(
+                "Invalid object name format. Expected format: '<id>/<prediction_type>/"
+                "<model_id>/<study_area_name>/<scenario_id>/<chunk_id>'"
+                "\nActual name: 'invalid_name'"
+            ),
+        ):
+            main.spatialize_chunk_predictions(flask.request)
 
 
 @mock.patch.object(storage.client, "Client", autospec=True)
@@ -71,20 +64,6 @@ def test_spatialize_chunk_predictions_invalid_object_name() -> None:
 def test_spatialize_chunk_predictions_missing_study_area(
     mock_firestore_client, mock_storage_client
 ) -> None:
-    event = http.CloudEvent(
-        {
-            "type": "google.cloud.pubsub.topic.v1.messagePublished",
-            "source": "source",
-        },
-        {
-            "message": {
-                "data": base64.b64encode(
-                    b"id/prediction-type/model-id/study-area-name/scenario-id/chunk-id"
-                ),
-            }
-        },
-    )
-
     # Build mock Storage object
     predictions = (
         '{"instance": {"values": [1, 2, 3, 4], "key": 1},'
@@ -99,11 +78,13 @@ def test_spatialize_chunk_predictions_missing_study_area(
     )
     mock_study_area_ref.get().exists = False  # Indicate study area doesn't exist
 
-    output = io.StringIO()
-    with contextlib.redirect_stdout(output):
-        main.spatialize_chunk_predictions(event)
-
-    assert 'Study area "study-area-name" does not exist' in output.getvalue()
+    with _create_request_context(
+        "id/prediction-type/model-id/study-area-name/scenario-id/chunk-id"
+    ):
+        with pytest.raises(
+            ValueError, match='Study area "study-area-name" does not exist'
+        ):
+            main.spatialize_chunk_predictions(flask.request)
 
 
 @mock.patch.object(storage.client, "Client", autospec=True)
@@ -111,20 +92,6 @@ def test_spatialize_chunk_predictions_missing_study_area(
 def test_spatialize_chunk_predictions_invalid_study_area(
     mock_firestore_client, mock_storage_client
 ) -> None:
-    event = http.CloudEvent(
-        {
-            "type": "google.cloud.pubsub.topic.v1.messagePublished",
-            "source": "source",
-        },
-        {
-            "message": {
-                "data": base64.b64encode(
-                    b"id/prediction-type/model-id/study-area-name/scenario-id/chunk-id"
-                ),
-            }
-        },
-    )
-
     # Build mock Storage object
     predictions = (
         '{"instance": {"values": [1, 2, 3, 4], "key": 1},'
@@ -158,14 +125,17 @@ def test_spatialize_chunk_predictions_invalid_study_area(
     mock_chunks_ref = mock_study_area_ref.collection("chunks")
     mock_chunks_ref.get.return_value = chunks_metadata
 
-    output = io.StringIO()
-    with contextlib.redirect_stdout(output):
-        main.spatialize_chunk_predictions(event)
-
-    assert (
-        'Study area "study-area-name" is missing one or more required '
-        "fields: cell_size, crs, chunk_x_count, chunk_y_count" in output.getvalue()
-    )
+    with _create_request_context(
+        "id/prediction-type/model-id/study-area-name/scenario-id/chunk-id"
+    ):
+        with pytest.raises(
+            ValueError,
+            match=(
+                'Study area "study-area-name" is missing one or more required '
+                "fields: cell_size, crs, chunk_x_count, chunk_y_count"
+            ),
+        ):
+            main.spatialize_chunk_predictions(flask.request)
 
 
 @mock.patch.object(storage.client, "Client", autospec=True)
@@ -173,20 +143,6 @@ def test_spatialize_chunk_predictions_invalid_study_area(
 def test_spatialize_chunk_predictions_missing_chunk(
     mock_firestore_client, mock_storage_client
 ) -> None:
-    event = http.CloudEvent(
-        {
-            "type": "google.cloud.pubsub.topic.v1.messagePublished",
-            "source": "source",
-        },
-        {
-            "message": {
-                "data": base64.b64encode(
-                    b"id/prediction-type/model-id/study-area-name/scenario-id/chunk-id"
-                ),
-            }
-        },
-    )
-
     # Build mock Storage object
     predictions = (
         '{"instance": {"values": [1, 2, 3, 4], "key": 1},'
@@ -222,11 +178,11 @@ def test_spatialize_chunk_predictions_missing_chunk(
     mock_chunks_ref.get.return_value = chunks_metadata
     mock_chunks_ref.document("chunk-id").get().exists = False
 
-    output = io.StringIO()
-    with contextlib.redirect_stdout(output):
-        main.spatialize_chunk_predictions(event)
-
-    assert 'Chunk "chunk-id" does not exist' in output.getvalue()
+    with _create_request_context(
+        "id/prediction-type/model-id/study-area-name/scenario-id/chunk-id"
+    ):
+        with pytest.raises(ValueError, match='Chunk "chunk-id" does not exist'):
+            main.spatialize_chunk_predictions(flask.request)
 
 
 @mock.patch.object(storage.client, "Client", autospec=True)
@@ -234,20 +190,6 @@ def test_spatialize_chunk_predictions_missing_chunk(
 def test_spatialize_chunk_predictions_invalid_chunk(
     mock_firestore_client, mock_storage_client
 ) -> None:
-    event = http.CloudEvent(
-        {
-            "type": "google.cloud.pubsub.topic.v1.messagePublished",
-            "source": "source",
-        },
-        {
-            "message": {
-                "data": base64.b64encode(
-                    b"id/prediction-type/model-id/study-area-name/scenario-id/chunk-id"
-                ),
-            }
-        },
-    )
-
     # Build mock Storage object
     predictions = (
         '{"instance": {"values": [1, 2, 3, 4], "key": 1},'
@@ -282,14 +224,17 @@ def test_spatialize_chunk_predictions_invalid_chunk(
     mock_chunks_ref.get.return_value = chunks_metadata
     mock_chunks_ref.document("chunk-id").get().to_dict.return_value = chunks_metadata[0]
 
-    output = io.StringIO()
-    with contextlib.redirect_stdout(output):
-        main.spatialize_chunk_predictions(event)
-
-    assert (
-        'Chunk "chunk-id" is missing one or more required '
-        "fields: row_count, col_count, x_ll_corner, y_ll_corner" in output.getvalue()
-    )
+    with _create_request_context(
+        "id/prediction-type/model-id/study-area-name/scenario-id/chunk-id"
+    ):
+        with pytest.raises(
+            ValueError,
+            match=(
+                'Chunk "chunk-id" is missing one or more required '
+                "fields: row_count, col_count, x_ll_corner, y_ll_corner"
+            ),
+        ):
+            main.spatialize_chunk_predictions(flask.request)
 
 
 @mock.patch.object(storage.client, "Client", autospec=True)
@@ -297,20 +242,6 @@ def test_spatialize_chunk_predictions_invalid_chunk(
 def test_spatialize_chunk_predictions_missing_predictions(
     mock_firestore_client, mock_storage_client
 ) -> None:
-    event = http.CloudEvent(
-        {
-            "type": "google.cloud.pubsub.topic.v1.messagePublished",
-            "source": "source",
-        },
-        {
-            "message": {
-                "data": base64.b64encode(
-                    b"id/prediction-type/model-id/study-area-name/scenario-id/chunk-id"
-                ),
-            }
-        },
-    )
-
     # Build mock Storage object
     predictions = ""
     with mock_storage_client().bucket("").blob("").open() as mock_fd:
@@ -343,14 +274,17 @@ def test_spatialize_chunk_predictions_missing_predictions(
     mock_chunks_ref.get.return_value = chunks_metadata
     mock_chunks_ref.document("chunk-id").get().to_dict.return_value = chunks_metadata[0]
 
-    output = io.StringIO()
-    with contextlib.redirect_stdout(output):
-        main.spatialize_chunk_predictions(event)
-
-    assert (
-        "Predictions file: id/prediction-type/model-id/study-area-name/scenario-id/"
-        "chunk-id is missing." in output.getvalue()
-    )
+    with _create_request_context(
+        "id/prediction-type/model-id/study-area-name/scenario-id/chunk-id"
+    ):
+        with pytest.raises(
+            ValueError,
+            match=(
+                "Predictions file: id/prediction-type/model-id/study-area-name/"
+                "scenario-id/chunk-id is missing."
+            ),
+        ):
+            main.spatialize_chunk_predictions(flask.request)
 
 
 @mock.patch.object(storage.client, "Client", autospec=True)
@@ -358,20 +292,6 @@ def test_spatialize_chunk_predictions_missing_predictions(
 def test_spatialize_chunk_predictions_too_many_predictions(
     mock_firestore_client, mock_storage_client
 ) -> None:
-    event = http.CloudEvent(
-        {
-            "type": "google.cloud.pubsub.topic.v1.messagePublished",
-            "source": "source",
-        },
-        {
-            "message": {
-                "data": base64.b64encode(
-                    b"id/prediction-type/model-id/study-area-name/scenario-id/chunk-id"
-                ),
-            }
-        },
-    )
-
     # Build mock Storage object
     predictions = (
         '{"instance": {"values": [1, 2, 3, 4], "key": 1},'
@@ -410,11 +330,13 @@ def test_spatialize_chunk_predictions_too_many_predictions(
     mock_chunk_ref = mock_study_area_ref.collection("chunks").document("chunk-id")
     mock_chunk_ref.get().to_dict.return_value = chunks_metadata[0]
 
-    output = io.StringIO()
-    with contextlib.redirect_stdout(output):
-        main.spatialize_chunk_predictions(event)
-
-    assert "Predictions file has too many predictions" in output.getvalue()
+    with _create_request_context(
+        "id/prediction-type/model-id/study-area-name/scenario-id/chunk-id"
+    ):
+        with pytest.raises(
+            ValueError, match="Predictions file has too many predictions"
+        ):
+            main.spatialize_chunk_predictions(flask.request)
 
 
 @mock.patch.object(storage.client, "Client", autospec=True)
@@ -422,20 +344,6 @@ def test_spatialize_chunk_predictions_too_many_predictions(
 def test_spatialize_chunk_predictions_missing_expected_neighbor_chunk(
     mock_firestore_client, mock_storage_client
 ) -> None:
-    event = http.CloudEvent(
-        {
-            "type": "google.cloud.pubsub.topic.v1.messagePublished",
-            "source": "source",
-        },
-        {
-            "message": {
-                "data": base64.b64encode(
-                    b"id/prediction-type/model-id/study-area-name/scenario-id/chunk-id"
-                ),
-            }
-        },
-    )
-
     # Build mock Storage object
     predictions = (
         '{"instance": {"values": [1, 2, 3, 4], "key": 1},'
@@ -474,12 +382,14 @@ def test_spatialize_chunk_predictions_missing_expected_neighbor_chunk(
         []
     )  # Neighbor chunks do not exist.
 
-    output = io.StringIO()
-    with contextlib.redirect_stdout(output):
-        main.spatialize_chunk_predictions(event)
-    assert "Neighbor chunk at index (0, 1) is missing from the study area" in str(
-        output.getvalue()
-    )
+    with _create_request_context(
+        "id/prediction-type/model-id/study-area-name/scenario-id/chunk-id"
+    ):
+        with pytest.raises(
+            ValueError,
+            match="Neighbor chunk at index (0, 1) is missing from the study area",
+        ):
+            main.spatialize_chunk_predictions(flask.request)
 
 
 @mock.patch.object(storage.client, "Client", autospec=True)
@@ -487,20 +397,6 @@ def test_spatialize_chunk_predictions_missing_expected_neighbor_chunk(
 def test_spatialize_chunk_predictions_invalid_neighbor_chunk(
     mock_firestore_client, mock_storage_client
 ) -> None:
-    event = http.CloudEvent(
-        {
-            "type": "google.cloud.pubsub.topic.v1.messagePublished",
-            "source": "source",
-        },
-        {
-            "message": {
-                "data": base64.b64encode(
-                    b"id/prediction-type/model-id/study-area-name/scenario-id/chunk-id"
-                ),
-            }
-        },
-    )
-
     # Build mock Storage object
     predictions = (
         '{"instance": {"values": [1, 2, 3, 4], "key": 1},'
@@ -543,15 +439,17 @@ def test_spatialize_chunk_predictions_invalid_neighbor_chunk(
     neighbor_metadata_mock.to_dict.return_value = neighbor_metadata
     mock_chunks_ref.where().where().limit().get.return_value = [neighbor_metadata_mock]
 
-    output = io.StringIO()
-    with contextlib.redirect_stdout(output):
-        main.spatialize_chunk_predictions(event)
-
-    assert (
-        "Neighbor chunk at index (0, 1) is missing one or more required fields: id,"
-        " row_count, col_count, x_ll_corner,y_ll_corner, x_index, y_index"
-        in output.getvalue()
-    )
+    with _create_request_context(
+        "id/prediction-type/model-id/study-area-name/scenario-id/chunk-id"
+    ):
+        with pytest.raises(
+            ValueError,
+            match=(
+                "Neighbor chunk at index (0, 1) is missing one or more required fields:"
+                " id, row_count, col_count, x_ll_corner,y_ll_corner, x_index, y_index"
+            ),
+        ):
+            main.spatialize_chunk_predictions(flask.request)
 
 
 @mock.patch.object(storage.client, "Client", autospec=True)
@@ -559,20 +457,6 @@ def test_spatialize_chunk_predictions_invalid_neighbor_chunk(
 def test_spatialize_chunk_predictions_neighbor_chunk_missing_predictions(
     mock_firestore_client, mock_storage_client
 ) -> None:
-    event = http.CloudEvent(
-        {
-            "type": "google.cloud.pubsub.topic.v1.messagePublished",
-            "source": "source",
-        },
-        {
-            "message": {
-                "data": base64.b64encode(
-                    b"id/prediction-type/model-id/study-area-name/scenario-id/chunk-id"
-                ),
-            }
-        },
-    )
-
     # Build mock Storage object
     predictions = (
         '{"instance": {"values": [1, 2, 3, 4], "key": 1},'
@@ -616,14 +500,17 @@ def test_spatialize_chunk_predictions_neighbor_chunk_missing_predictions(
     neighbor_metadata_mock.to_dict.return_value = neighbor_metadata
     mock_chunks_ref.where().where().limit().get.return_value = [neighbor_metadata_mock]
 
-    output = io.StringIO()
-    with contextlib.redirect_stdout(output):
-        main.spatialize_chunk_predictions(event)
-
-    assert (
-        "Predictions file: id/prediction-type/model-id/study-area-name/scenario-id/"
-        "neighbor-chunk-id is missing."
-    ) in output.getvalue()
+    with _create_request_context(
+        "id/prediction-type/model-id/study-area-name/scenario-id/chunk-id"
+    ):
+        with pytest.raises(
+            ValueError,
+            match=(
+                "Predictions file: id/prediction-type/model-id/study-area-name/"
+                "scenario-id/neighbor-chunk-id is missing."
+            ),
+        ):
+            main.spatialize_chunk_predictions(flask.request)
 
 
 @mock.patch.object(storage.client, "Client", autospec=True)
@@ -631,20 +518,6 @@ def test_spatialize_chunk_predictions_neighbor_chunk_missing_predictions(
 def test_spatialize_chunk_predictions_h3_centroids_within_chunk(
     mock_firestore_client, mock_storage_client, tmp_path
 ) -> None:
-    event = http.CloudEvent(
-        {
-            "type": "google.cloud.pubsub.topic.v1.messagePublished",
-            "source": "source",
-        },
-        {
-            "message": {
-                "data": base64.b64encode(
-                    b"id/prediction-type/model-id/study-area-name/scenario-id/chunk-id"
-                ),
-            }
-        },
-    )
-
     # Build mock Storage object
     predictions = (
         '{"instance": {"values": [1, 2, 3, 4], "key": 1},'
@@ -723,7 +596,10 @@ def test_spatialize_chunk_predictions_h3_centroids_within_chunk(
     )
     expected_series.index.name = "h3_index"
 
-    main.spatialize_chunk_predictions(event)
+    with _create_request_context(
+        "id/prediction-type/model-id/study-area-name/scenario-id/chunk-id"
+    ):
+        main.spatialize_chunk_predictions(flask.request)
 
     pd.testing.assert_series_equal(
         pd.read_csv(output_file_path, index_col=0)["prediction"],
@@ -737,20 +613,6 @@ def test_spatialize_chunk_predictions_h3_centroids_within_chunk(
 def test_spatialize_chunk_predictions_h3_centroids_outside_chunk(
     mock_firestore_client, mock_storage_client, tmp_path
 ) -> None:
-    event = http.CloudEvent(
-        {
-            "type": "google.cloud.pubsub.topic.v1.messagePublished",
-            "source": "source",
-        },
-        {
-            "message": {
-                "data": base64.b64encode(
-                    b"id/prediction-type/model-id/study-area-name/scenario-id/chunk-id"
-                ),
-            }
-        },
-    )
-
     # Build mock Storage object
     predictions = (
         '{"instance":  {"values": [1, 2, 3, 4], "key": 1},'
@@ -842,7 +704,10 @@ def test_spatialize_chunk_predictions_h3_centroids_outside_chunk(
     )
     expected_series.index.name = "h3_index"
 
-    main.spatialize_chunk_predictions(event)
+    with _create_request_context(
+        "id/prediction-type/model-id/study-area-name/scenario-id/chunk-id"
+    ):
+        main.spatialize_chunk_predictions(flask.request)
 
     pd.testing.assert_series_equal(
         pd.read_csv(output_file_path, index_col=0)["prediction"],
@@ -856,20 +721,6 @@ def test_spatialize_chunk_predictions_h3_centroids_outside_chunk(
 def test_spatialize_chunk_predictions_overlapping_neighbors(
     mock_firestore_client, mock_storage_client, tmp_path
 ) -> None:
-    event = http.CloudEvent(
-        {
-            "type": "google.cloud.pubsub.topic.v1.messagePublished",
-            "source": "source",
-        },
-        {
-            "message": {
-                "data": base64.b64encode(
-                    b"id/prediction-type/model-id/study-area-name/scenario-id/chunk-id"
-                ),
-            }
-        },
-    )
-
     # Build mock Storage object
     predictions = (
         '{"instance":  {"values": [1, 2, 3, 4], "key": 1}, '
@@ -1068,7 +919,10 @@ def test_spatialize_chunk_predictions_overlapping_neighbors(
     )
     expected_series.index.name = "h3_index"
 
-    main.spatialize_chunk_predictions(event)
+    with _create_request_context(
+        "id/prediction-type/model-id/study-area-name/scenario-id/chunk-id"
+    ):
+        main.spatialize_chunk_predictions(flask.request)
 
     pd.testing.assert_series_equal(
         pd.read_csv(output_file_path, index_col=0)["prediction"],

--- a/cloud_functions/climateiq_trigger_export_pipeline_cf/main.py
+++ b/cloud_functions/climateiq_trigger_export_pipeline_cf/main.py
@@ -1,15 +1,24 @@
+from concurrent import futures
 import functions_framework
 import pathlib
 import json
 import os
+import time
 
-from google.cloud import storage, pubsub_v1
+from google.cloud import pubsub_v1, storage
 from cloudevents import http
 
 INPUT_BUCKET_NAME = os.environ.get("BUCKET_PREFIX", "") + "climateiq-predictions"
 OUTPUT_BUCKET_NAME = os.environ.get("BUCKET_PREFIX", "") + "climateiq-chunk-predictions"
 CLIMATEIQ_PROJECT_ID = "climateiq-" + os.environ.get("BUCKET_PREFIX", "").rstrip("-")
 CLIMATEIQ_EXPORT_PIPELINE_TOPIC_ID = "climateiq-spatialize-and-export-predictions"
+
+
+def _write_file(line: str, output_filename: str, storage_client: storage.Client):
+    output_blob = storage_client.bucket(OUTPUT_BUCKET_NAME).blob(output_filename)
+    # Specify retry here due to bug:
+    # https://github.com/googleapis/python-storage/issues/1242
+    output_blob.upload_from_string(line, retry=storage.retry.DEFAULT_RETRY)
 
 
 @functions_framework.cloud_event
@@ -27,44 +36,45 @@ def trigger_export_pipeline(cloud_event: http.CloudEvent) -> None:
     Args:
         cloud_event: The CloudEvent representing the storage event.
     """
+    start = time.time()
+
     data = cloud_event.data
     object_name = data["name"]
 
+    # Structured logging:
+    # https://cloud.google.com/functions/docs/monitoring/logging#writing_structured_logs
+    print(json.dumps(dict(severity="DEBUG", message=f"[{object_name}] CF started")))
+
     # Extract components from the object name and determine the total number of
     # output prediction files.
-    #
-    # Note: Invalid object name is a non-retriable error so we return instead
-    # of throwing an exception (which would trigger retries).
     expected_format = (
         "<id>/<prediction_type>/<model_id>/<study_area_name>/"
         "<scenario_id>/prediction.results-<file_number>-of-{number_of_files_generated}"
     )
     path = pathlib.PurePosixPath(object_name)
     if len(path.parts) != 6:
-        print(
+        raise ValueError(
             f"Invalid object name format. Expected format: '{expected_format}'\n"
             f"Actual name: '{object_name}'"
         )
-        return
     id, prediction_type, model_id, study_area_name, scenario_id, filename = path.parts
     if filename.count("-") != 3:
-        print(
+        raise ValueError(
             f"Invalid object name format. Expected format: '{expected_format}'\n"
             f"Actual name: '{object_name}'"
         )
-        return
     _, _, _, file_count = filename.split("-")
     if prediction_type != "flood":
-        print("Export pipeline can currently only be used for flood predictions.")
-        return
+        raise ValueError(
+            "Export pipeline can currently only be used for flood predictions."
+        )
     try:
         total_prediction_files = int(file_count)
     except ValueError:
-        print(
+        raise ValueError(
             f"Invalid object name format. Expected format: '{expected_format}'\n"
             f"Actual name: '{object_name}'"
         )
-        return
 
     # Retrieve all input prediction files.
     storage_client = storage.Client()
@@ -85,19 +95,34 @@ def trigger_export_pipeline(cloud_event: http.CloudEvent) -> None:
 
     # Split predictions into one file per chunk and output to GCS.
     output_filenames = []
-    for blob in input_blobs:
-        with blob.open() as fd:
-            for line in fd:
-                chunk_id = json.loads(line)["instance"]["key"]
-                output_filename = (
-                    f"{id}/{prediction_type}/{model_id}/"
-                    f"{study_area_name}/{scenario_id}/{chunk_id}"
-                )
-                output_filenames.append(output_filename)
-                output_blob = storage_client.bucket(OUTPUT_BUCKET_NAME).blob(
-                    output_filename
-                )
-                output_blob.upload_from_string(line)
+    write_futures = []
+    with futures.ThreadPoolExecutor() as executor:
+        for blob in input_blobs:
+            with blob.open() as fd:
+                for line in fd:
+                    chunk_id = json.loads(line)["instance"]["key"]
+                    output_filename = (
+                        f"{id}/{prediction_type}/{model_id}/"
+                        f"{study_area_name}/{scenario_id}/{chunk_id}"
+                    )
+                    output_filenames.append(output_filename)
+                    future = executor.submit(
+                        _write_file, line, output_filename, storage_client
+                    )
+                    write_futures.append(future)
+
+    futures.wait(write_futures)
+    print(
+        json.dumps(
+            dict(
+                severity="DEBUG",
+                message=(
+                    f"[{object_name}] Created {len(output_filenames)} files in "
+                    f"{time.time() - start} s."
+                ),
+            )
+        )
+    )
 
     # Once all output files have been written, publish pubsub message per chunk to kick
     # off export pipeline.
@@ -105,10 +130,23 @@ def trigger_export_pipeline(cloud_event: http.CloudEvent) -> None:
     topic_path = publisher.topic_path(
         CLIMATEIQ_PROJECT_ID, CLIMATEIQ_EXPORT_PIPELINE_TOPIC_ID
     )
+    publish_futures = []
     for output_filename in output_filenames:
         future = publisher.publish(
             topic_path,
             data=output_filename.encode("utf-8"),
             origin="climateiq_trigger_export_pipeline_cf",
         )
-        print(future.result())
+        publish_futures.append(future)
+    futures.wait(publish_futures)
+    print(
+        json.dumps(
+            dict(
+                severity="DEBUG",
+                message=(
+                    f"[{object_name}] Started export pipeline for "
+                    f"{len(output_filenames)} chunks."
+                ),
+            )
+        )
+    )


### PR DESCRIPTION
We will change the CF to not retry the entire process on error.

This PR has three commits - one to update trigger_export, one to update spatialize, and one to change spatialize to be triggered by HTTP. They can be reviewed separately.